### PR TITLE
Add Workshop favicons to the Venture Studio Simulator

### DIFF
--- a/venturestudio/index.html
+++ b/venturestudio/index.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Venture Studio Simulator</title>
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/brand/favicon-32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/assets/brand/favicon-16.png" />
+  <link rel="apple-touch-icon" href="/assets/brand/favicon-180.png" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>


### PR DESCRIPTION
The simulator at /venturestudio/ is standalone static HTML with its own <head> and no favicon link, so it fell back to the old favicon.ico. Add the same Workshop favicon links the main site uses (32/16 + apple-touch-180).