### PR TITLE
MoP Website: live metrics band, Advisory contact cleanup, spin all hairline gears (MIN-1006, MIN-1009, MIN-1010)

### DIFF
--- a/advisory.md
+++ b/advisory.md
@@ -68,5 +68,5 @@ Example projects we've taken from concept to launch:
 
 ---
 
-[Get in touch →](mailto:info-at-ministryofproduct.com) [Explore the Venture Studio →](/venture-studio/)
+[Explore the Venture Studio →](/venture-studio/)
 {: .cta-row}

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -295,7 +295,7 @@ a:hover { color: var(--text-link-hover); text-decoration: underline; }
     linear-gradient(var(--surface-card), var(--surface-card)) center / 44px 100% no-repeat,
     linear-gradient(var(--mop-iron-300), var(--mop-iron-300)) center / 100% var(--border-width-rule) no-repeat;
 }
-.glass-content hr { margin: 2.5rem 0; }
+.glass-content hr { margin: 2.5rem 0; position: relative; }
 /* the footer's top hairline gets the same engraved gear, for consistency */
 .glass-content footer::before { content: ""; display: block; margin-bottom: 2rem; }
 /* Remove the static gear from footer::before — the spinning ::after takes over */
@@ -318,6 +318,29 @@ a:hover { color: var(--text-link-hover); text-decoration: underline; }
 }
 @media (prefers-reduced-motion: no-preference) {
   .glass-content footer::after {
+    animation: mop-spin 45s linear infinite;
+  }
+}
+/* Remove the static gear from hr — the spinning ::after takes over */
+.glass-content hr {
+  background:
+    linear-gradient(var(--surface-card), var(--surface-card)) center / 44px 100% no-repeat,
+    linear-gradient(var(--mop-iron-300), var(--mop-iron-300)) center / 100% var(--border-width-rule) no-repeat;
+}
+/* Spinning gear on hr hairlines: same centered-box technique as footer */
+.glass-content hr::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 20px;
+  height: 24px;
+  margin: 0 auto;
+  background: url("data:image/svg+xml,%3Csvg xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22 viewBox%3D%220 0 100 100%22 fill%3D%22%23B06A3A%22%3E%3Cpath fill-rule%3D%22evenodd%22 d%3D%22M 86.06 41.70 L 96.59 43.82 L 96.59 56.18 L 86.06 58.30 L 84.05 64.48 L 91.33 72.38 L 84.06 82.39 L 74.29 77.91 L 69.03 81.73 L 70.28 92.40 L 58.52 96.22 L 53.25 86.86 L 46.75 86.86 L 41.48 96.22 L 29.72 92.40 L 30.97 81.73 L 25.71 77.91 L 15.94 82.39 L 8.67 72.38 L 15.95 64.48 L 13.94 58.30 L 3.41 56.18 L 3.41 43.82 L 13.94 41.70 L 15.95 35.52 L 8.67 27.62 L 15.94 17.61 L 25.71 22.09 L 30.97 18.27 L 29.72 7.60 L 41.48 3.78 L 46.75 13.14 L 53.25 13.14 L 58.52 3.78 L 70.28 7.60 L 69.03 18.27 L 74.29 22.09 L 84.06 17.61 L 91.33 27.62 L 84.05 35.52 Z M50 30 A20 20 0 1 0 50.01 30 Z%22%3E%3C%2Fpath%3E%3Ccircle cx%3D%2250%22 cy%3D%2250%22 r%3D%228.5%22 fill%3D%22%23B06A3A%22%3E%3C%2Fcircle%3E%3C%2Fsvg%3E") center / 20px 20px no-repeat;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .glass-content hr::after {
     animation: mop-spin 45s linear infinite;
   }
 }

--- a/index.markdown
+++ b/index.markdown
@@ -28,10 +28,29 @@ Ministry of Product operates in two ways:
 - **Advisory & Consulting** helps founder-led teams make better product, AI, and operational decisions — and builds the software when it's the right move.
 
 <div class="mop-stats">
-  <div class="stat"><span class="num">20</span><span class="lbl">Years<br>shipping</span></div>
-  <div class="stat"><span class="num">3</span><span class="lbl">Ventures<br>launched</span></div>
-  <div class="stat"><span class="num">5</span><span class="lbl">Pathway<br>stages</span></div>
+  <div class="stat"><span class="num" id="stat-fragments">336</span><span class="lbl">Ideas<br>explored</span></div>
+  <div class="stat"><span class="num" id="stat-ventures">14</span><span class="lbl">Ventures<br>taking shape</span></div>
+  <div class="stat"><span class="num">20</span><span class="lbl">Years<br>of craft</span></div>
 </div>
+<script>
+(function () {
+  var FLOOR_FRAGMENTS = 50;
+  var FLOOR_VENTURES  = 10;
+  var elF = document.getElementById('stat-fragments');
+  var elV = document.getElementById('stat-ventures');
+  fetch('https://idea-growth-backend-mop-j6pdv7rpoq-uc.a.run.app/api/stats/public')
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+      if (elF && typeof data.fragments === 'number' && data.fragments >= FLOOR_FRAGMENTS) {
+        elF.textContent = data.fragments.toLocaleString();
+      }
+      if (elV && typeof data.ventures === 'number' && data.ventures >= FLOOR_VENTURES) {
+        elV.textContent = data.ventures.toLocaleString();
+      }
+    })
+    .catch(function () { /* network failure — static fallback values remain */ });
+}());
+</script>
 
 ---
 


### PR DESCRIPTION
Second batch from the **MoP Website** Linear Todo column, each implemented on its model tier and verified against the running Jekyll dev server (and visually in-browser).

## Issues implemented
- **MIN-1006 — Live homepage metrics band.** Replaces the static `20 / 3 / 5` band with **`336 Ideas explored · 14 Ventures taking shape · 20 Years of craft`** — the first two pulled live (client-side `fetch`) from the new Innovation Commons public stats endpoint (`/api/stats/public`), the third a static anchor. Includes graceful fallback (static values if the fetch fails) and per-slot floors so a quiet period can't show a thin number. Endpoint built/tracked in MIN-1011; "go fully live later" tracked in MIN-1012.
- **MIN-1009 — Remove "Get in touch" on Advisory.** Drops the `mailto:` CTA so all contact routes through the "Start a conversation" form.
- **MIN-1010 — Spin the gear on all hairlines.** Generalizes the footer hairline gear-spin (MIN-1003) to every `hr` divider, reusing the existing `mop-spin` keyframes, gated behind `prefers-reduced-motion`. Gear alignment on the hairline confirmed in-browser.

## Reviewer notes (Fable → opus fallback)
> Fable 5 was unavailable, so the whole-batch review ran on the highest available tier (opus). Read-only review over the full `main...HEAD` diff; clean `jekyll build`, all pages render.

**Blocker:** None.

**Should-fix:** None.

**Nit:**
- `index.markdown` (MIN-1006): the ventures fallback is `14` while the floor is `10`, so if the backend returns a live value between 10 and 13 the displayed number would dip below the static fallback. Consistent with the "floor prevents absurd lows" intent and acceptable live behavior — just noting the fallback isn't a hard floor on the displayed figure. (Currently moot: live `ventures` is 14.)

**Verified:** MIN-1006 reads only `fragments`/`ventures` (never `ideas`/`members`/`projects`), floors + `toLocaleString` present, `.catch()` keeps the static fallback, no Liquid-brace hazard. MIN-1009: mailto gone, `.cta-row` + layout form intact, no orphaned divider. MIN-1010: exactly one `@keyframes mop-spin`, static-gear strip wins by source order (no double-render), mirrors the proven `footer::after` technique. Files are disjoint — no cross-ticket conflicts.

**Recommendation: SHIP** — all acceptance criteria met, build clean, no regressions; only a benign nit remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
